### PR TITLE
Add isDefined() and getPointId() to hrleDenseIterator.

### DIFF
--- a/include/hrleDenseIterator.hpp
+++ b/include/hrleDenseIterator.hpp
@@ -149,6 +149,10 @@ public:
     }
   }
 
+  bool isDefined() const { return runsIterator.isDefined(); }
+
+  hrleSizeType getPointId() const { return runsIterator.getPointId(); }
+
   hrleValueType &getValue() { return runsIterator.getValue(); }
 
   hrleIndexType getIndex(int dimension) { return currentIndices[dimension]; }


### PR DESCRIPTION
There's no good way to access this information from a full-grid iteration otherwise.