### PR TITLE
Bugfix in hrleSparseOffsetIterator

### DIFF
--- a/include/hrleGrid.hpp
+++ b/include/hrleGrid.hpp
@@ -200,6 +200,11 @@ public:
     return boundaryConditions[dim] == PERIODIC_BOUNDARY;
   }
 
+  /// returns wheter the boundary condition in direction dim is reflective
+  bool isBoundaryReflective(int dim) const {
+    return boundaryConditions[dim] == REFLECTIVE_BOUNDARY;
+  }
+
   /// returns wheter the boundary condition in direction +dim is infinite
   bool isPosBoundaryInfinite(int dim) const {
     return ((boundaryConditions[dim] == INFINITE_BOUNDARY) ||

--- a/include/hrleSparseOffsetIterator.hpp
+++ b/include/hrleSparseOffsetIterator.hpp
@@ -829,9 +829,17 @@ public:
     for (unsigned i = 0; i < D; ++i) {
       indices[i] += offset[i];
       if (indices[i] > gridMax[i]) {
-        indices[i] = gridMin[i] + (indices[i] - gridMax[i] - 1);
+        if(grid.isBoundaryReflective(i)){
+          indices[i] = gridMax[i] - 1;
+        }else{
+          indices[i] = gridMin[i] + (indices[i] - gridMax[i] - 1);
+        }
       } else if (indices[i] < gridMin[i]) {
-        indices[i] = gridMax[i] + (indices[i] - gridMin[i] + 1);
+        if(grid.isBoundaryReflective(i)){
+          indices[i] = gridMin[i] + 1;
+        }else{
+          indices[i] = gridMax[i] + (indices[i] - gridMin[i] + 1);
+        }
       }
     }
     return indices;


### PR DESCRIPTION
The function getOffsetIndices() in hrleSparseOffsetIterator.hpp did not distinguish between boundary conditions (implicitly assumed that the boundary condition is periodic when it is not infinite).

Best,
Christoph