### PR TITLE
Static order in iterators

### DIFF
--- a/Examples/CrossIterator/CrossIterator.cpp
+++ b/Examples/CrossIterator/CrossIterator.cpp
@@ -41,8 +41,8 @@ int main() {
       '.'); // last parameter is the background value to use
 
   // go to the first 'l' and output all neighbors
-  const int order = 3;
-  hrleConstSparseStarIterator<hrleDomain<char, D>> neighborIt(data, order);
+  constexpr int order = 3;
+  hrleConstSparseStarIterator<hrleDomain<char, D>, order> neighborIt(data);
   while (!(neighborIt.getCenter().getValue() == 'l')) {
     neighborIt.next();
   }

--- a/Examples/SquareIterator/SquareIterator.cpp
+++ b/Examples/SquareIterator/SquareIterator.cpp
@@ -42,7 +42,7 @@ int main() {
       '.'); // last parameter is the background value to use
 
   // go to the first 'l' and output all neighbors
-  const int order = 2;
+  constexpr int order = 2;
   hrleSparseBoxIterator<hrleDomain<char, D>> neighborIt(data, order);
   while (!(neighborIt.getCenter().getValue() == 'l')) {
     neighborIt.next();
@@ -61,7 +61,7 @@ int main() {
   }
 
   // make cross iterator for comparison and advance to the first 'l'
-  hrleConstSparseStarIterator<hrleDomain<char, D>> crossIt(data, order);
+  hrleConstSparseStarIterator<hrleDomain<char, D>, order> crossIt(data);
   while (!(crossIt.getCenter().getValue() == 'l')) {
     crossIt.next();
   }

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ViennaHRLE is a header-only C++ library for storing sparse spatial data efficiently. In the worst case, traversing the whole data structure is achieved in O(N), where N is the number of data points stored in the structure. Random access is achieved in O(log(N)).
 
-IMPORTANT NOTE: ViennaHRLE is under heavy development and improved daily. If you do have suggestions or find bugs, please let us know!
-
 ## Support
 For help with getting started, have a look at the [Examples](https://github.com/ViennaTools/viennahrle/tree/master/Examples).
 

--- a/include/hrleDenseCellIterator.hpp
+++ b/include/hrleDenseCellIterator.hpp
@@ -126,8 +126,8 @@ public:
 
   void next() {
     const int numCorners = 1 << D;
-    std::vector<bool> increment(numCorners, false);
-    increment[0] = true;
+    // std::vector<bool> increment(numCorners, false);
+    // increment[0] = true;
 
     hrleVectorType<hrleIndexType, D> end_coords = currentCoords;
     // cornerIterators[0].getEndIndices();
@@ -146,8 +146,8 @@ public:
 
   void previous() {
     const int numCorners = 1 << D;
-    std::vector<bool> decrement(numCorners, false);
-    decrement[0] = true;
+    // std::vector<bool> decrement(numCorners, false);
+    // decrement[0] = true;
 
     hrleVectorType<hrleIndexType, D> start_coords = currentCoords;
     // cornerIterators[0].getStartIndices();

--- a/include/hrleSparseCellIterator.hpp
+++ b/include/hrleSparseCellIterator.hpp
@@ -85,7 +85,8 @@ public:
   void next() {
     do {
       const int numCorners = 1 << D;
-      std::vector<bool> increment(numCorners, false);
+      std::array<bool, 1 << D> increment;
+      increment.fill(false);
       increment[0] = true;
 
       hrleVectorType<hrleIndexType, D> end_coords =
@@ -94,7 +95,7 @@ public:
         switch (compare(end_coords, cornerIterators[i].getEndIndices())) {
         case 1:
           end_coords = cornerIterators[i].getEndIndices();
-          increment = std::vector<bool>(numCorners, false);
+          increment.fill(false);
         case 0:
           increment[i] = true;
         }
@@ -111,7 +112,8 @@ public:
   void previous() {
     do {
       const int numCorners = 1 << D;
-      std::vector<bool> decrement(numCorners, false);
+      std::array<bool, 1 << D> decrement;
+      decrement.fill(false);
       decrement[0] = true;
 
       hrleVectorType<hrleIndexType, D> start_coords =
@@ -120,7 +122,7 @@ public:
         switch (compare(start_coords, cornerIterators[i].getStartIndices())) {
         case -1:
           start_coords = cornerIterators[i].getStartIndices();
-          decrement = std::vector<bool>(numCorners, false);
+          decrement.fill(false);
         case 0:
           decrement[i] = true;
         }


### PR DESCRIPTION
Changed the order, which determines the number of neighbors, to a static parameter in iterators when it is possible. Specifically, this concerns hrleSparseStarIterator and hrleSparseCellIterator. 